### PR TITLE
Replace "integer" types with "int", to suppress warnings in PHP 7.4 and PHP 8.0

### DIFF
--- a/source/Trader.php
+++ b/source/Trader.php
@@ -1504,7 +1504,7 @@ class Trader
      * @return int Returns the error code identified by one of the TRADER_ERR_* constants.
      * @throws \Exception
      */
-    public static function errorNumber(): integer
+    public static function errorNumber(): int
     {
         return static::errno();
     }
@@ -1547,7 +1547,7 @@ class Trader
      * @return int Returns the compatibility mode id which can be identified by TRADER_COMPATIBILITY_* series of constants.
      * @throws \Exception
      */
-    public static function getCompatibilityMode(): integer
+    public static function getCompatibilityMode(): int
     {
         return static::get_compat();
     }
@@ -1562,7 +1562,7 @@ class Trader
      * @return int Returns the unstable period factor for the corresponding function.
      * @throws \Exception
      */
-    public static function getUnstablePeriod(integer $functionId): integer
+    public static function getUnstablePeriod(int $functionId): int
     {
         return static::get_unstable_period($functionId);
     }
@@ -2242,7 +2242,7 @@ class Trader
      *
      * @throws \Exception
      */
-    public static function setCompatibilityMode(integer $compatId)
+    public static function setCompatibilityMode(int $compatId)
     {
         static::set_compat($compatId);
     }
@@ -2256,7 +2256,7 @@ class Trader
      *
      * @throws \Exception
      */
-    public static function setUnstablePeriod(integer $functionId, int $timePeriod)
+    public static function setUnstablePeriod(int $functionId, int $timePeriod)
     {
         static::set_unstable_period($functionId, $timePeriod);
     }

--- a/source/TraderTrait.php
+++ b/source/TraderTrait.php
@@ -1776,7 +1776,7 @@ trait TraderTrait
      * @return int Returns the error code identified by one of the TRADER_ERR_* constants.
      * @throws \Exception
      */
-    public static function errno(): integer
+    public static function errno(): int
     {
         $return = trader_errno();
         static::checkForError();
@@ -1825,7 +1825,7 @@ trait TraderTrait
      * @return int Returns the compatibility mode id which can be identified by TRADER_COMPATIBILITY_* series of constants.
      * @throws \Exception
      */
-    public static function get_compat(): integer
+    public static function get_compat(): int
     {
         $return = trader_get_compat();
         static::checkForError();
@@ -1842,7 +1842,7 @@ trait TraderTrait
      * @return int Returns the unstable period factor for the corresponding function.
      * @throws \Exception
      */
-    public static function get_unstable_period(integer $functionId): integer
+    public static function get_unstable_period(int $functionId): int
     {
         $return = trader_get_unstable_period($functionId);
         static::checkForError();
@@ -2707,7 +2707,7 @@ trait TraderTrait
      *
      * @throws \Exception
      */
-    public static function set_compat(integer $compatId)
+    public static function set_compat(int $compatId)
     {
         trader_set_compat($compatId);
         static::checkForError();
@@ -2722,7 +2722,7 @@ trait TraderTrait
      *
      * @throws \Exception
      */
-    public static function set_unstable_period(integer $functionId, int $timePeriod)
+    public static function set_unstable_period(int $functionId, int $timePeriod)
     {
         trader_set_unstable_period($functionId, $timePeriod);
         static::checkForError();


### PR DESCRIPTION
Since PHP 7.4, the alias `integer` can no longer be used as a scalar type. Instead, `int` must be used. [See here](https://www.php.net/manual/en/language.types.declarations.php) for some more info. When loading this package under PHP 8.0, this warning gets thrown in 12 separate places:

```
PHP Warning:  "integer" will be interpreted as a class name. Did you mean "int"? Write "\LupeCode\phpTraderInterface\integer" or import the class with "use" to suppress this warning in /home/vagrant/my-site/vendor/lupecode/php-trader-interface/source/Trader.php on line 1507
```

This PR simply replaces the few instances of `integer` with `int`... and makes the errors go away.

Thanks for a useful package!